### PR TITLE
Add preferences for kano start page etc.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: <insert the upstream URL, if relevant>
 #Vcs-Git: git://anonscm.debian.org/collab-maint/chromium.git
 #Vcs-Browser: http://anonscm.debian.org/?p=collab-maint/chromium.git;a=summary
 
-Package: rpi-chromium-mods
+Package: rpi-chromium-mods-kano
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, chromium-browser
 Replaces: chromium-browser

--- a/master_preferences
+++ b/master_preferences
@@ -1,4 +1,22 @@
 {
+        "session": {
+            "restore_on_startup": 4,
+            "startup_urls": [
+                "http://start.kano.me/"
+            ]
+        },
+        "distribution": {
+              "import_bookmarks": false,
+              "import_bookmarks_from_file": "/etc/chromium/initial_bookmarks.html",
+              "skip_first_run_ui": true,
+              "make_chrome_default": false,
+              "make_chrome_default_for_user": false,
+              "create_all_shortcuts": true,
+              "show_welcome_page": false
+        },
+        "bookmark_bar": {
+           "show_on_all_tabs": false
+        },
 	"alternate_error_pages": {
 		"enabled":false
 	},
@@ -67,7 +85,9 @@
 		}
 	},
 	"browser": {
-		"custom_chrome_frame":false
+		"custom_chrome_frame":false,
+                "show_home_button": true,
+                "check_default_browser" : false
 	},
 	"default_search_provider": {
 		"synced_guid":"9A111FB4-A8D3-4FDD-84CE-76178E50246B"


### PR DESCRIPTION
This PR adds the prefs which were removed from https://github.com/KanoComputing/kano-desktop/pull/202
The homepage pref has changed format since chromium was updated.

(The RPI foundation has not made a github repo for this package (yet?) although http://dev.kano.me/mirrors/raspberrypi-jessie/pool/ui/r/rpi-chromium-mods/rpi-chromium-mods_0.1.orig.tar.xz contains a git repo. This repository is therefore based on this and
http://dev.kano.me/mirrors/raspberrypi-jessie/pool/ui/r/rpi-chromium-mods/rpi-chromium-mods_0.1-1.debian.tar.xz . If they do so, we can rebase this repo on it.)
@tombettany @radujipa 
